### PR TITLE
feat(protocol): add protocol option

### DIFF
--- a/nordvpn-server-find
+++ b/nordvpn-server-find
@@ -18,6 +18,7 @@ OPTIND=1
 location=false
 capacity=30 # Default capacity value is 30%
 limit=20 # Default limit value is 20
+protocol=tcp # Default protocol is tcp
 
 iso_codes=(
   'ad' 'ae' 'af' 'ag' 'ai' 'al' 'am' 'ao' 'aq' 'ar' 'as' 'at' 'au' 'aw' 'ax'
@@ -52,7 +53,7 @@ array_contains () {
   return $in
 }
 
-while getopts ":l:c:n:rh" opt; do
+while getopts ":p:l:c:n:rh" opt; do
     case "$opt" in
     h)
       echo
@@ -62,6 +63,7 @@ while getopts ":l:c:n:rh" opt; do
       echo "-l   $(tput smul)location$(tput rmul)      2-letter ISO 3166-1 country code (ex: us, uk, de)"
       echo "-c   $(tput smul)capacity$(tput rmul)      current server load, integer between 1-100 (defaults to 30)"
       echo "-n   $(tput smul)limit$(tput rmul)         limits number of results, integer between 1-100 (defaults to 20)"
+      echo "-p   $(tput smul)protocol$(tput rmul)      protocol to support, either tcp or udp (defaults to tcp)"
       echo
       exit 0
       ;;
@@ -105,6 +107,19 @@ while getopts ":l:c:n:rh" opt; do
         }
       fi
       ;;
+    p)
+      if [ "$OPTARG" == "tcp" ] || [ "$OPTARG" = "udp" ];
+      then
+        protocol=$OPTARG >&2;
+      else
+        {
+          >&2 echo "Invalid protocol parameter."
+          >&2 echo "Please provide either tcp or udp (tcp by default)"
+          >&2 echo "(ex: -p upd)"
+          exit 1
+        }
+      fi
+      ;;
     :)
       >&2 echo "Option -$OPTARG requires an argument."
       >&2 echo "Use -h to show the help."
@@ -131,14 +146,27 @@ echo
 echo "Looking for servers located in $(tput bold)${location^^}$(tput sgr0) with server load lower than $(tput bold)$capacity%$(tput sgr0)..."
 echo
 
+server_descriptions=$(curl --silent https://api.nordvpn.com/server)
+server_stats=$(curl --silent https://nordvpn.com/api/server/stats)
 
-servers=$(curl --silent https://nordvpn.com/api/server/stats)
 
 # Declare and populate array
+matches=()
+while read -r server_name
+do
+  matches+=($server_name)
+done < <(jq --compact-output -r --arg protocol "$protocol" --arg location "$location" \
+  '.[] |
+  select((($protocol == "tcp") and (.features.openvpn_tcp == true)) or (($protocol == "udp") and (.features.openvpn_upd = true))) |
+  select(.domain | contains($location)) |
+  .domain' <<<$server_descriptions)
+
 declare -A results
 while IFS="=" read -r key value
 do
+  if [[ " ${matches[@]} " =~ " ${key} " ]]; then
     results[$key]="$value"
+  fi
 done < <(jq --compact-output -r --arg location "$location" --arg capacity "$capacity" --arg limit "$limit" \
   '[. |
   to_entries[] |
@@ -149,7 +177,7 @@ done < <(jq --compact-output -r --arg location "$location" --arg capacity "$capa
   from_entries |
   to_entries |
   map("\(.key)=\(.value|tostring)") |
-  limit(($limit|tonumber);.[])' <<<"$servers")
+  limit(($limit|tonumber);.[])' <<<"$server_stats")
 
 # Print out results
 if [ ${#results[@]} -eq 0 ]; then


### PR DESCRIPTION
Allow the user to specify a protocol they want the server to support, between tcp and udp

Most but not all servers support these two protocols. This change makes the script a bit safer when scripting so that one can suffix appropriately with ".tcp" or ".udp" the nm connection to be used.